### PR TITLE
AttackEffect を Critical に設定していると Slime も出る

### DIFF
--- a/src/main/java/work/siro/mod/pvpparticles/EffectManager.java
+++ b/src/main/java/work/siro/mod/pvpparticles/EffectManager.java
@@ -82,8 +82,10 @@ public class EffectManager {
 				break;
 			case AttackEffect.CRITICAL:
 				emitParticleAtEntity(entity, EnumParticleTypes.CRIT);
+				break;
 			case AttackEffect.SLIME:
 				emitParticleAtEntity(entity, EnumParticleTypes.SLIME);
+				break;
 		}
 	}
 


### PR DESCRIPTION
AttackEffect を Critical に設定していると Slime も出るバグ

[10059fa](https://github.com/SiroQ/PvPParticles/pull/1/commits/10059fa7f1d5666166f160d6e948a4ec3d3ad361) で修正

![eb4229980d83aac27204fbdfff7df0c3](https://t.gyazo.com/teams/omn/eb4229980d83aac27204fbdfff7df0c3.png "eb4229980d83aac27204fbdfff7df0c3")